### PR TITLE
[#19] Cleaning the house

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,13 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.5.0
 commit = False
 tag = False
 
 [bumpversion:file:pyproject.toml]
 search = version = "{current_version}"
 replace = version = "{new_version}"
+
+[bumpversion:file:README.md]
+search = version-{current_version}-blue
+replace = version-{new_version}-blue
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -15,6 +15,7 @@ Supported languages: English, Catalan, Spanish.
 **Stack:**
 - Python 3.13+, managed by `uv`
 - FastAPI + uvicorn (API + web simulator)
+- Typer (CLI — `wordclock` and `wordclock-generate` entry points)
 - jinja2 + aiofiles (templates + static files)
 - rpi-ws281x (Raspberry Pi only, optional extra)
 - pytest + pytest-cov + ruff + pre-commit (dev)

--- a/README.md
+++ b/README.md
@@ -4,18 +4,28 @@
 
 > **🚧 Work in progress** — this project is under active development and not yet complete.
 
-[![CI](https://github.com/eballo/word-clock/actions/workflows/ci.yml/badge.svg)](https://github.com/eballo/word-clock/actions/workflows/ci.yml) [![Version](https://img.shields.io/badge/version-0.1.0-blue.svg)](#) [![Python](https://img.shields.io/badge/python-3.13-3776AB?logo=python&logoColor=white)](https://www.python.org/) [![FastAPI](https://img.shields.io/badge/FastAPI-009688?logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com/) [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv) [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff) [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit) [![License](https://img.shields.io/badge/license-GPL--3.0-green.svg)](LICENSE)
+[![CI](https://github.com/eballo/word-clock/actions/workflows/ci.yml/badge.svg)](https://github.com/eballo/word-clock/actions/workflows/ci.yml) [![Version](https://img.shields.io/badge/version-0.5.0-blue.svg)](#) [![Python](https://img.shields.io/badge/python-3.13-3776AB?logo=python&logoColor=white)](https://www.python.org/) [![FastAPI](https://img.shields.io/badge/FastAPI-009688?logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com/) [![Typer](https://img.shields.io/badge/Typer-000000?logo=python&logoColor=white)](https://typer.tiangolo.com/) [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv) [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff) [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit) [![License](https://img.shields.io/badge/license-GPL--3.0-green.svg)](LICENSE)
 
 A 65 × 65 cm word clock with a 16 × 16 LED matrix (256 LEDs) driven by a Raspberry Pi.
 The front panel is 3D-printed and interchangeable, allowing the clock to display time
 in different languages without any hardware changes.
+
+## Motivation
+
+I love the look of word clocks and have wanted one for a long time. The problem is that
+most of the ones I found — whether commercial or open-source — are in English or German.
+I wanted one in Catalan, and I could not find it anywhere.
+
+So I decided to build my own. This project documents the full process step by step: the
+hardware, the software, the 3D-printed panel, and everything in between. I am not an expert
+in any of these areas, so things will change as I experiment and learn.
 
 ## Repository structure
 
 ```
 word-clock/
 ├── prototype/    # Browser-based JavaScript simulator to validate the grid layout
-├── wordclock/    # Python package — LED control, time logic, FastAPI and web UI
+├── wordclock/    # Python package — LED control, time logic, FastAPI + Typer CLI and web UI
 ├── tests/        # Unit and integration tests
 ├── docs/         # Step-by-step build documentation
 └── README.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "aiofiles>=24.0",
     "fastapi>=0.115",
     "jinja2>=3.1",
+    "typer>=0.12",
     "uvicorn>=0.30",
 ]
 
@@ -27,10 +28,8 @@ dev = [
 ]
 
 [project.scripts]
-wordclock          = "wordclock.main:main"
-wordclock-api      = "wordclock.api.app:main"
-wordclock-serve    = "wordclock.main:main_serve"
-wordclock-generate = "wordclock.layouts.utils:main"
+wordclock          = "wordclock.main:app"
+wordclock-generate = "wordclock.layouts.utils.cli:app"
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -1,5 +1,3 @@
-"""Shared fixtures for API integration tests."""
-
 from __future__ import annotations
 
 import pytest

--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -1,5 +1,3 @@
-"""Integration tests — core API endpoints."""
-
 from __future__ import annotations
 
 from fastapi.testclient import TestClient

--- a/tests/integration/api/test_languages.py
+++ b/tests/integration/api/test_languages.py
@@ -1,5 +1,3 @@
-"""Integration tests — multi-language API endpoints."""
-
 from __future__ import annotations
 
 from fastapi.testclient import TestClient

--- a/tests/unit/layouts/layout_test_mixin.py
+++ b/tests/unit/layouts/layout_test_mixin.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from types import ModuleType
+
+import pytest
+
+
+class GetLedsForTimeMixin:
+    """Shared tests for get_leds_for_time — inherit in each layout's TestGetLedsForTime."""
+
+    mod: ModuleType
+
+    def test_result_contains_required_keys(self) -> None:
+        # Given / When
+        result = self.mod.get_leds_for_time(10, 0)
+        # Then
+        assert all(k in result for k in ("sentence", "coords", "led_indices", "hours", "minutes"))
+
+    def test_led_indices_are_integers(self) -> None:
+        # Given / When
+        result = self.mod.get_leds_for_time(10, 0)
+        # Then
+        assert all(isinstance(i, int) for i in result["led_indices"])
+
+    def test_led_indices_within_grid_bounds(self) -> None:
+        # Given / When
+        result = self.mod.get_leds_for_time(10, 0)
+        # Then
+        max_idx = self.mod.NUM_ROWS * self.mod.NUM_COLS - 1
+        assert all(0 <= i <= max_idx for i in result["led_indices"])
+
+    def test_hours_and_minutes_echoed_in_result(self) -> None:
+        # Given
+        hours, minutes = 7, 35
+        # When
+        result = self.mod.get_leds_for_time(hours, minutes)
+        # Then
+        assert result["hours"] == hours
+        assert result["minutes"] == minutes
+
+
+class SentenceToCoordsMixin:
+    """Shared tests for sentence_to_coords — inherit in each layout's TestSentenceToCoords."""
+
+    mod: ModuleType
+    sample_sentence: str
+
+    def test_coords_within_grid_bounds(self) -> None:
+        # Given / When
+        coords = self.mod.sentence_to_coords(self.sample_sentence)
+        # Then
+        for row, col in coords:
+            assert 0 <= row < self.mod.NUM_ROWS
+            assert 0 <= col < self.mod.NUM_COLS
+
+    def test_no_duplicate_coords(self) -> None:
+        # Given / When
+        coords = self.mod.sentence_to_coords(self.sample_sentence)
+        # Then
+        assert len(coords) == len(set(coords))
+
+
+class AllTimesMixin:
+    """Shared parametrized test that every time produces a non-empty sentence."""
+
+    mod: ModuleType
+
+    @pytest.mark.parametrize("h,m", [(h, m) for h in range(24) for m in range(0, 60, 5)])
+    def test_all_times_produce_non_empty_sentence(self, h: int, m: int) -> None:
+        # Given: any valid time
+        # When
+        result = self.mod.time_to_sentence(h, m)
+        # Then
+        assert len(result) > 0

--- a/tests/unit/layouts/test_base.py
+++ b/tests/unit/layouts/test_base.py
@@ -1,5 +1,3 @@
-"""Unit tests — shared base functions (create_layout, coords_to_led_indices)."""
-
 from __future__ import annotations
 
 from wordclock.layouts.base import coords_to_led_indices

--- a/tests/unit/layouts/test_catalan_layout.py
+++ b/tests/unit/layouts/test_catalan_layout.py
@@ -1,19 +1,22 @@
-"""Unit tests — Catalan layout."""
-
 from __future__ import annotations
 
-import pytest
-
+import wordclock.layouts.catalan as _mod
+from tests.unit.layouts.layout_test_mixin import (
+    AllTimesMixin,
+    GetLedsForTimeMixin,
+    SentenceToCoordsMixin,
+)
 from wordclock.layouts.catalan import (
     NUM_COLS,
     NUM_ROWS,
-    get_leds_for_time,
     sentence_to_coords,
     time_to_sentence,
 )
 
 
-class TestTimeToSentence:
+class TestTimeToSentence(AllTimesMixin):
+    mod = _mod
+
     def test_en_punt_singular(self) -> None:
         # Given: hour 1 uses singular verb and article
         hours, minutes = 1, 0
@@ -141,33 +144,10 @@ class TestTimeToSentence:
         # Then
         assert result == "ÉS LA UNA EN PUNT"
 
-    @pytest.mark.parametrize("h,m", [(h, m) for h in range(24) for m in range(0, 60, 5)])
-    def test_all_times_produce_non_empty_sentence(self, h: int, m: int) -> None:
-        # Given: any valid time
-        # When
-        result = time_to_sentence(h, m)
-        # Then
-        assert len(result) > 0
 
-
-class TestSentenceToCoords:
-    def test_coords_within_grid_bounds(self) -> None:
-        # Given
-        sentence = "SÓN DOS QUARTS DE DEU"
-        # When
-        coords = sentence_to_coords(sentence)
-        # Then
-        for row, col in coords:
-            assert 0 <= row < NUM_ROWS
-            assert 0 <= col < NUM_COLS
-
-    def test_no_duplicate_coords(self) -> None:
-        # Given
-        sentence = "ÉS UN QUART DE DEU"
-        # When
-        coords = sentence_to_coords(sentence)
-        # Then
-        assert len(coords) == len(set(coords))
+class TestSentenceToCoords(SentenceToCoordsMixin):
+    mod = _mod
+    sample_sentence = "SÓN DOS QUARTS DE DEU"
 
     def test_apostrophe_sentence_resolves_coords(self) -> None:
         # Given: sentence with D' preposition that must be split before searching
@@ -181,37 +161,5 @@ class TestSentenceToCoords:
             assert 0 <= col < NUM_COLS
 
 
-class TestGetLedsForTime:
-    def test_result_contains_required_keys(self) -> None:
-        # Given
-        hours, minutes = 10, 15
-        # When
-        result = get_leds_for_time(hours, minutes)
-        # Then
-        assert all(k in result for k in ("sentence", "coords", "led_indices", "hours", "minutes"))
-
-    def test_led_indices_are_integers(self) -> None:
-        # Given
-        hours, minutes = 10, 30
-        # When
-        result = get_leds_for_time(hours, minutes)
-        # Then
-        assert all(isinstance(i, int) for i in result["led_indices"])
-
-    def test_led_indices_within_grid_bounds(self) -> None:
-        # Given
-        hours, minutes = 10, 45
-        # When
-        result = get_leds_for_time(hours, minutes)
-        # Then
-        max_idx = NUM_ROWS * NUM_COLS - 1
-        assert all(0 <= i <= max_idx for i in result["led_indices"])
-
-    def test_hours_and_minutes_echoed_in_result(self) -> None:
-        # Given
-        hours, minutes = 4, 45
-        # When
-        result = get_leds_for_time(hours, minutes)
-        # Then
-        assert result["hours"] == hours
-        assert result["minutes"] == minutes
+class TestGetLedsForTime(GetLedsForTimeMixin):
+    mod = _mod

--- a/tests/unit/layouts/test_english_layout.py
+++ b/tests/unit/layouts/test_english_layout.py
@@ -1,19 +1,20 @@
-"""Unit tests — English layout."""
-
 from __future__ import annotations
 
-import pytest
-
+import wordclock.layouts.english as _mod
+from tests.unit.layouts.layout_test_mixin import (
+    AllTimesMixin,
+    GetLedsForTimeMixin,
+    SentenceToCoordsMixin,
+)
 from wordclock.layouts.english import (
-    NUM_COLS,
-    NUM_ROWS,
-    get_leds_for_time,
     sentence_to_coords,
     time_to_sentence,
 )
 
 
-class TestTimeToSentence:
+class TestTimeToSentence(AllTimesMixin):
+    mod = _mod
+
     def test_oclock(self) -> None:
         # Given: time exactly on the hour
         hours, minutes = 10, 0
@@ -137,33 +138,10 @@ class TestTimeToSentence:
         for h in range(24):
             assert time_to_sentence(h, 0).startswith("IT IS"), f"Failed for hour {h}"
 
-    @pytest.mark.parametrize("h,m", [(h, m) for h in range(24) for m in range(0, 60, 5)])
-    def test_all_times_produce_non_empty_sentence(self, h: int, m: int) -> None:
-        # Given: any valid time
-        # When
-        result = time_to_sentence(h, m)
-        # Then
-        assert len(result) > 0
 
-
-class TestSentenceToCoords:
-    def test_coords_within_grid_bounds(self) -> None:
-        # Given
-        sentence = "IT IS TEN OCLOCK"
-        # When
-        coords = sentence_to_coords(sentence)
-        # Then: every coord falls inside the grid
-        for row, col in coords:
-            assert 0 <= row < NUM_ROWS
-            assert 0 <= col < NUM_COLS
-
-    def test_no_duplicate_coords(self) -> None:
-        # Given
-        sentence = "IT IS HALF PAST TEN"
-        # When
-        coords = sentence_to_coords(sentence)
-        # Then
-        assert len(coords) == len(set(coords))
+class TestSentenceToCoords(SentenceToCoordsMixin):
+    mod = _mod
+    sample_sentence = "IT IS HALF PAST TEN"
 
     def test_it_is_lights_four_cells(self) -> None:
         # Given: only two words, four letters total
@@ -174,37 +152,5 @@ class TestSentenceToCoords:
         assert len(coords) == 4
 
 
-class TestGetLedsForTime:
-    def test_result_contains_required_keys(self) -> None:
-        # Given
-        hours, minutes = 10, 0
-        # When
-        result = get_leds_for_time(hours, minutes)
-        # Then
-        assert all(k in result for k in ("sentence", "coords", "led_indices", "hours", "minutes"))
-
-    def test_led_indices_are_integers(self) -> None:
-        # Given
-        hours, minutes = 10, 0
-        # When
-        result = get_leds_for_time(hours, minutes)
-        # Then
-        assert all(isinstance(i, int) for i in result["led_indices"])
-
-    def test_led_indices_within_grid_bounds(self) -> None:
-        # Given
-        hours, minutes = 10, 0
-        # When
-        result = get_leds_for_time(hours, minutes)
-        # Then
-        max_idx = NUM_ROWS * NUM_COLS - 1
-        assert all(0 <= i <= max_idx for i in result["led_indices"])
-
-    def test_hours_and_minutes_echoed_in_result(self) -> None:
-        # Given
-        hours, minutes = 7, 35
-        # When
-        result = get_leds_for_time(hours, minutes)
-        # Then
-        assert result["hours"] == hours
-        assert result["minutes"] == minutes
+class TestGetLedsForTime(GetLedsForTimeMixin):
+    mod = _mod

--- a/tests/unit/layouts/test_registry.py
+++ b/tests/unit/layouts/test_registry.py
@@ -1,5 +1,3 @@
-"""Unit tests — layout registry."""
-
 from __future__ import annotations
 
 import pytest

--- a/tests/unit/layouts/test_spanish_layout.py
+++ b/tests/unit/layouts/test_spanish_layout.py
@@ -1,19 +1,22 @@
-"""Unit tests — Spanish layout."""
-
 from __future__ import annotations
 
-import pytest
-
+import wordclock.layouts.spanish as _mod
+from tests.unit.layouts.layout_test_mixin import (
+    AllTimesMixin,
+    GetLedsForTimeMixin,
+    SentenceToCoordsMixin,
+)
 from wordclock.layouts.spanish import (
     NUM_COLS,
     NUM_ROWS,
-    get_leds_for_time,
     sentence_to_coords,
     time_to_sentence,
 )
 
 
-class TestTimeToSentence:
+class TestTimeToSentence(AllTimesMixin):
+    mod = _mod
+
     def test_en_punto_singular(self) -> None:
         # Given: hour 1 uses singular verb and article
         hours, minutes = 1, 0
@@ -105,33 +108,10 @@ class TestTimeToSentence:
         # Then
         assert result == "ES LA UNA EN PUNTO"
 
-    @pytest.mark.parametrize("h,m", [(h, m) for h in range(24) for m in range(0, 60, 5)])
-    def test_all_times_produce_non_empty_sentence(self, h: int, m: int) -> None:
-        # Given: any valid time
-        # When
-        result = time_to_sentence(h, m)
-        # Then
-        assert len(result) > 0
 
-
-class TestSentenceToCoords:
-    def test_coords_within_grid_bounds(self) -> None:
-        # Given
-        sentence = "SON LAS DIEZ Y MEDIA"
-        # When
-        coords = sentence_to_coords(sentence)
-        # Then
-        for row, col in coords:
-            assert 0 <= row < NUM_ROWS
-            assert 0 <= col < NUM_COLS
-
-    def test_no_duplicate_coords(self) -> None:
-        # Given
-        sentence = "ES LA UNA EN PUNTO"
-        # When
-        coords = sentence_to_coords(sentence)
-        # Then
-        assert len(coords) == len(set(coords))
+class TestSentenceToCoords(SentenceToCoordsMixin):
+    mod = _mod
+    sample_sentence = "SON LAS DIEZ Y MEDIA"
 
     def test_veinticinco_normalised_and_found(self) -> None:
         # Given: VEINTICINCO is split to VEINTE + CINCO before searching
@@ -153,37 +133,5 @@ class TestSentenceToCoords:
         assert len(coords) > 0
 
 
-class TestGetLedsForTime:
-    def test_result_contains_required_keys(self) -> None:
-        # Given
-        hours, minutes = 10, 30
-        # When
-        result = get_leds_for_time(hours, minutes)
-        # Then
-        assert all(k in result for k in ("sentence", "coords", "led_indices", "hours", "minutes"))
-
-    def test_led_indices_are_integers(self) -> None:
-        # Given
-        hours, minutes = 2, 15
-        # When
-        result = get_leds_for_time(hours, minutes)
-        # Then
-        assert all(isinstance(i, int) for i in result["led_indices"])
-
-    def test_led_indices_within_grid_bounds(self) -> None:
-        # Given
-        hours, minutes = 4, 45
-        # When
-        result = get_leds_for_time(hours, minutes)
-        # Then
-        max_idx = NUM_ROWS * NUM_COLS - 1
-        assert all(0 <= i <= max_idx for i in result["led_indices"])
-
-    def test_hours_and_minutes_echoed_in_result(self) -> None:
-        # Given
-        hours, minutes = 6, 20
-        # When
-        result = get_leds_for_time(hours, minutes)
-        # Then
-        assert result["hours"] == hours
-        assert result["minutes"] == minutes
+class TestGetLedsForTime(GetLedsForTimeMixin):
+    mod = _mod

--- a/uv.lock
+++ b/uv.lock
@@ -260,6 +260,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -309,6 +321,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -523,6 +544,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "rpi-ws281x"
 version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -554,6 +588,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -563,6 +606,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/27/ede8cec7596e0041ba7e7b80b47d132562f56ff454313a16f6084e555c9f/typer-0.25.0.tar.gz", hash = "sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930", size = 120150, upload-time = "2026-04-26T08:46:14.767Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/72/193d4e586ec5a4db834a36bbeb47641a62f951f114ffd0fe5b1b46e8d56f/typer-0.25.0-py3-none-any.whl", hash = "sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc", size = 55993, upload-time = "2026-04-26T08:46:15.889Z" },
 ]
 
 [[package]]
@@ -616,12 +674,13 @@ wheels = [
 
 [[package]]
 name = "wordclock"
-version = "0.4.1"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
     { name = "fastapi" },
     { name = "jinja2" },
+    { name = "typer" },
     { name = "uvicorn" },
 ]
 
@@ -648,6 +707,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "rpi-ws281x", marker = "extra == 'rpi'", specifier = ">=5.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9" },
+    { name = "typer", specifier = ">=0.12" },
     { name = "uvicorn", specifier = ">=0.30" },
 ]
 provides-extras = ["rpi", "dev"]

--- a/wordclock/api/app.py
+++ b/wordclock/api/app.py
@@ -1,11 +1,13 @@
-"""FastAPI application factory."""
-
 from __future__ import annotations
 
-from argparse import ArgumentParser
-from logging import DEBUG, INFO, basicConfig, getLogger
+import asyncio
+from collections.abc import Callable, Coroutine
+from contextlib import asynccontextmanager, suppress
+from logging import getLogger
 from pathlib import Path
+from typing import Any
 
+import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
@@ -17,47 +19,38 @@ from wordclock.layouts.registry import SUPPORTED_LANGUAGES, get_layout
 logger = getLogger(__name__)
 
 _WEB_DIR = Path(__file__).parent.parent / "web"
+_ClockLoop = Callable[[], Coroutine[Any, Any, None]]
 
 
-def create_app(led_controller=None) -> FastAPI:
-    app = FastAPI()
+def create_app(led_controller: Any = None, clock_loop: _ClockLoop | None = None) -> FastAPI:
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI):
+        if clock_loop:
+            task = asyncio.create_task(clock_loop())
+            try:
+                yield
+            finally:
+                task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await task
+        else:
+            yield
+
+    app = FastAPI(lifespan=lifespan)
     app.add_middleware(
         CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"]
     )
+    _layouts = {lang: get_layout(lang) for lang in SUPPORTED_LANGUAGES}
     app.state.led_controller = led_controller
-    app.state.grids = {lang: get_layout(lang).GRID_RAW for lang in SUPPORTED_LANGUAGES}
+    app.state.grids = {lang: _layouts[lang].GRID_RAW for lang in SUPPORTED_LANGUAGES}
+    app.state.dims = {
+        lang: (_layouts[lang].NUM_ROWS, _layouts[lang].NUM_COLS) for lang in SUPPORTED_LANGUAGES
+    }
     app.state.templates = Jinja2Templates(directory=_WEB_DIR / "templates")
     app.mount("/static", StaticFiles(directory=_WEB_DIR / "static"), name="static")
     app.include_router(router)
     return app
 
 
-def _run_app(app: FastAPI, host: str, port: int, debug: bool) -> None:
-    import uvicorn
-
-    uvicorn.run(app, host=host, port=port, log_level="debug" if debug else "info")
-
-
-def main() -> None:
-    parser = ArgumentParser(description="Wordclock API server")
-    parser.add_argument("--host", default="0.0.0.0")
-    parser.add_argument("--port", "-p", default=5000, type=int)
-    parser.add_argument("--mock", action="store_true")
-    parser.add_argument("--debug", action="store_true")
-    args = parser.parse_args()
-
-    basicConfig(
-        level=DEBUG if args.debug else INFO,
-        format="%(asctime)s %(levelname)-8s %(name)s — %(message)s",
-    )
-
-    from wordclock.led.controller import create_controller
-
-    ctrl = create_controller(mock=args.mock)
-    app = create_app(led_controller=ctrl)
-    logger.info("Wordclock API → http://%s:%d", args.host, args.port)
-    _run_app(app, host=args.host, port=args.port, debug=args.debug)
-
-
-if __name__ == "__main__":
-    main()
+def run_app(app: FastAPI, host: str, port: int, debug: bool) -> None:
+    uvicorn.run(app, host=host, port=port, log_level="debug" if debug else "info", log_config=None)

--- a/wordclock/api/routes.py
+++ b/wordclock/api/routes.py
@@ -1,23 +1,30 @@
-"""FastAPI route handlers."""
-
 from __future__ import annotations
 
 from datetime import datetime
+from importlib.metadata import version
 from logging import getLogger
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
-from wordclock.layouts.registry import SUPPORTED_LANGUAGES, get_layout
+from wordclock.api.schemas import BrightnessResponse, GridResponse, HealthResponse, TimeResponse
+from wordclock.layouts.registry import Language, get_layout
 
 logger = getLogger(__name__)
 
-router = APIRouter()
+router = APIRouter(prefix="/api")
 
 
 class BrightnessRequest(BaseModel):
     brightness: int
+
+
+def _resolve_lang(lang: str) -> Language:
+    try:
+        return Language(lang)
+    except ValueError:
+        raise HTTPException(status_code=400, detail=f"Unknown language: {lang}")
 
 
 def _push_leds(request: Request, indices: list[int]) -> None:
@@ -31,36 +38,34 @@ def index(request: Request) -> HTMLResponse:
     return request.app.state.templates.TemplateResponse(request, "index.html")
 
 
-@router.get("/api/health")
-def health() -> dict:
-    return {"status": "ok", "version": "0.1.0"}
+@router.get("/health", response_model=HealthResponse)
+def health() -> HealthResponse:
+    return HealthResponse(status="ok", version=version("wordclock"))
 
 
-@router.get("/api/grid")
-def get_grid(request: Request, lang: str = "english") -> dict:
-    if lang not in SUPPORTED_LANGUAGES:
-        raise HTTPException(status_code=400, detail=f"Unknown language: {lang}")
-    logger.debug("Fetching grid for language: %s", lang)
-    layout = get_layout(lang)
-    grid = request.app.state.grids[lang]
-    return {
-        "language": lang,
-        "rows": layout.NUM_ROWS,
-        "cols": layout.NUM_COLS,
-        "grid": [list(row) for row in grid],
-    }
+@router.get("/grid", response_model=GridResponse)
+def get_grid(request: Request, lang: str = "english") -> GridResponse:
+    lang_enum = _resolve_lang(lang)
+    logger.debug("Fetching grid for language: %s", lang_enum.value)
+    grid = request.app.state.grids[lang_enum.value]
+    rows, cols = request.app.state.dims[lang_enum.value]
+    return GridResponse(
+        language=lang_enum.value,
+        rows=rows,
+        cols=cols,
+        grid=[list(row) for row in grid],
+    )
 
 
-@router.get("/api/time")
+@router.get("/time", response_model=TimeResponse)
 def get_time(
     request: Request,
     lang: str = "english",
     h: int | None = None,
     m: int | None = None,
-) -> dict:
-    if lang not in SUPPORTED_LANGUAGES:
-        raise HTTPException(status_code=400, detail=f"Unknown language: {lang}")
-    logger.debug("Fetching time for language: %s, h: %s, m: %s", lang, h, m)
+) -> TimeResponse:
+    lang_enum = _resolve_lang(lang)
+    logger.debug("Fetching time for language: %s, h: %s, m: %s", lang_enum.value, h, m)
     now = datetime.now()
     h = h if h is not None else now.hour
     m = m if m is not None else now.minute
@@ -68,25 +73,25 @@ def get_time(
         raise HTTPException(status_code=400, detail="h must be 0-23")
     if not (0 <= m <= 59):
         raise HTTPException(status_code=400, detail="m must be 0-59")
-    layout = get_layout(lang)
-    grid = request.app.state.grids[lang]
+    layout = get_layout(lang_enum)
+    grid = request.app.state.grids[lang_enum.value]
     result = layout.get_leds_for_time(h, m, grid=grid)
     _push_leds(request, result["led_indices"])
-    return {
-        "language": lang,
-        "hours": result["hours"],
-        "minutes": result["minutes"],
-        "sentence": result["sentence"],
-        "coords": result["coords"],
-        "led_indices": result["led_indices"],
-    }
+    return TimeResponse(
+        language=lang_enum.value,
+        hours=result["hours"],
+        minutes=result["minutes"],
+        sentence=result["sentence"],
+        coords=result["coords"],
+        led_indices=result["led_indices"],
+    )
 
 
-@router.post("/api/brightness")
-def set_brightness(request: Request, body: BrightnessRequest) -> dict:
+@router.post("/brightness", response_model=BrightnessResponse)
+def set_brightness(request: Request, body: BrightnessRequest) -> BrightnessResponse:
     if not (0 <= body.brightness <= 255):
         raise HTTPException(status_code=400, detail="brightness must be an integer 0-255")
     ctrl = request.app.state.led_controller
     if ctrl:
         ctrl.brightness = body.brightness
-    return {"brightness": body.brightness}
+    return BrightnessResponse(brightness=body.brightness)

--- a/wordclock/api/schemas.py
+++ b/wordclock/api/schemas.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class HealthResponse(BaseModel):
+    status: str
+    version: str
+
+
+class GridResponse(BaseModel):
+    language: str
+    rows: int
+    cols: int
+    grid: list[list[str]]
+
+
+class TimeResponse(BaseModel):
+    language: str
+    hours: int
+    minutes: int
+    sentence: str
+    coords: list[tuple[int, int]]
+    led_indices: list[int]
+
+
+class BrightnessResponse(BaseModel):
+    brightness: int

--- a/wordclock/clock.py
+++ b/wordclock/clock.py
@@ -1,75 +1,69 @@
-"""Clock loop and combined serve logic."""
-
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime
 from logging import getLogger
-from time import sleep
+
+from wordclock.api.app import create_app, run_app
+from wordclock.config import (
+    API_HOST,
+    API_PORT,
+    CLOCK_INTERVAL,
+    CLOCK_LANG,
+    LED_BRIGHTNESS,
+    LED_COLOR,
+)
+from wordclock.layouts.registry import get_layout
+from wordclock.led.controller import create_controller
 
 logger = getLogger(__name__)
 
 
-def run_clock(
-    lang: str = "english",
-    mock: bool = False,
-    brightness: int = 128,
-    interval: int = 30,
-    color: tuple[int, int, int] = (255, 200, 50),
-    ctrl=None,
-) -> None:
-    from wordclock.layouts.english import GRID_RAW, get_leds_for_time
-    from wordclock.led.controller import create_controller
+class WordClock:
+    def __init__(
+        self,
+        lang: str = CLOCK_LANG,
+        mock: bool = False,
+        display: bool = False,
+        brightness: int = LED_BRIGHTNESS,
+        interval: int = CLOCK_INTERVAL,
+        color: tuple[int, int, int] = LED_COLOR,
+    ) -> None:
+        self._interval = interval
+        self._color = color
+        self._last_sentence = ""
 
-    grid = GRID_RAW
-    if ctrl is None:
-        ctrl = create_controller(mock=mock, brightness=brightness, grid=grid if mock else None)
+        layout = get_layout(lang)
+        self._grid = layout.GRID_RAW
+        self._get_leds_for_time = layout.get_leds_for_time
+        self._ctrl = create_controller(
+            mock=mock, brightness=brightness, grid=self._grid if display else None
+        )
 
-    logger.info("Wordclock starting (lang=%s, mode=%s)", lang, "mock" if mock else "real")
+        logger.info("Wordclock starting (lang=%s, mode=%s)", lang, "mock" if mock else "real")
 
-    last_sentence = ""
-    try:
-        while True:
-            now = datetime.now()
-            result = get_leds_for_time(now.hour, now.minute, grid=grid)
+    async def _loop(self) -> None:
+        try:
+            while True:
+                now = datetime.now()
+                result = self._get_leds_for_time(now.hour, now.minute, grid=self._grid)
+                if result["sentence"] != self._last_sentence:
+                    logger.info("%02d:%02d → %s", now.hour, now.minute, result["sentence"])
+                    self._ctrl.display_leds(result["led_indices"], color=self._color)
+                    self._last_sentence = result["sentence"]
+                await asyncio.sleep(self._interval)
+        except asyncio.CancelledError:
+            logger.info("Stopping...")
+            self._ctrl.clear()
+            raise
 
-            if result["sentence"] != last_sentence:
-                logger.info("%02d:%02d → %s", now.hour, now.minute, result["sentence"])
-                ctrl.display_leds(result["led_indices"], color=color)
-                last_sentence = result["sentence"]
+    def run(self) -> None:
+        try:
+            asyncio.run(self._loop())
+        except KeyboardInterrupt:
+            pass
 
-            sleep(interval)
-
-    except KeyboardInterrupt:
-        logger.info("Stopping...")
-        ctrl.clear()
-
-
-def serve(
-    lang: str = "english",
-    mock: bool = False,
-    brightness: int = 128,
-    interval: int = 30,
-    color: tuple[int, int, int] = (255, 200, 50),
-    host: str = "0.0.0.0",
-    port: int = 5000,
-    debug: bool = False,
-) -> None:
-    import threading
-
-    from wordclock.api.app import _run_app, create_app
-    from wordclock.layouts.english import GRID_RAW
-    from wordclock.led.controller import create_controller
-
-    grid = GRID_RAW
-    ctrl = create_controller(mock=mock, brightness=brightness, grid=grid if mock else None)
-
-    clock_thread = threading.Thread(
-        target=run_clock,
-        kwargs=dict(lang=lang, interval=interval, color=color, ctrl=ctrl),
-        daemon=True,
-    )
-    clock_thread.start()
-
-    logger.info("Wordclock API → http://%s:%d", host, port)
-    app = create_app(led_controller=ctrl)
-    _run_app(app, host=host, port=port, debug=debug)
+    def serve(self, host: str = API_HOST, port: int = API_PORT, debug: bool = False) -> None:
+        logger.info("Wordclock API → http://%s:%d", host, port)
+        app = create_app(led_controller=self._ctrl, clock_loop=self._loop)
+        run_app(app, host=host, port=port, debug=debug)

--- a/wordclock/config.py
+++ b/wordclock/config.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+# LED hardware (WS2812B strip on Raspberry Pi)
+LED_COUNT: int = 256
+LED_PIN: int = 18
+LED_BRIGHTNESS: int = 128
+LED_FREQ_HZ: int = 800_000
+LED_DMA: int = 10
+LED_COLOR: tuple[int, int, int] = (255, 200, 50)
+
+# Clock loop
+CLOCK_INTERVAL: int = 30
+CLOCK_LANG: str = "catalan"
+
+# API server
+API_HOST: str = "0.0.0.0"
+API_PORT: int = 5000

--- a/wordclock/layouts/base.py
+++ b/wordclock/layouts/base.py
@@ -1,5 +1,3 @@
-"""Shared types, protocol, and functions for all layout modules."""
-
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -80,6 +78,41 @@ def sentence_to_coords(
                     break
 
     return coords
+
+
+def build_leds_for_time(
+    hours: int,
+    minutes: int,
+    *,
+    grid: list[str],
+    num_rows: int,
+    num_cols: int,
+    time_to_sentence_fn: Callable[[int, int], str],
+    normalize: dict[str, str] | None = None,
+    snake: bool = True,
+) -> LedResult:
+    """
+    Build a :class:`LedResult` for a given time using the provided layout parameters.
+
+    Args:
+        hours: Hour value 0-23.
+        minutes: Minute value 0-59.
+        grid: Display grid to search.
+        num_rows: Number of rows in the grid.
+        num_cols: Number of columns in the grid.
+        time_to_sentence_fn: Language-specific sentence builder.
+        normalize: Optional substitutions passed to :func:`sentence_to_coords`.
+        snake: Apply snake wiring. Default ``True``.
+
+    Returns:
+        :class:`LedResult` dict.
+    """
+    s = time_to_sentence_fn(hours, minutes)
+    coords = sentence_to_coords(s, grid, num_rows, normalize=normalize)
+    led_indices = coords_to_led_indices(coords, num_cols, snake=snake)
+    return LedResult(
+        sentence=s, coords=coords, led_indices=led_indices, hours=hours, minutes=minutes
+    )
 
 
 def coords_to_led_indices(

--- a/wordclock/layouts/catalan.py
+++ b/wordclock/layouts/catalan.py
@@ -18,9 +18,10 @@ from __future__ import annotations
 
 import wordclock.layouts.base as base
 from wordclock.layouts.base import LedResult
+from wordclock.layouts.registry import Language
 from wordclock.layouts.utils import load_grid
 
-GRID_RAW: list[str] = load_grid("catalan")
+GRID_RAW: list[str] = load_grid(Language.catalan)
 
 NUM_ROWS: int = len(GRID_RAW)
 NUM_COLS: int = len(GRID_RAW[0])
@@ -114,20 +115,6 @@ def sentence_to_coords(sentence: str, grid: list[str] | None = None) -> list[tup
     )
 
 
-def coords_to_led_indices(coords: list[tuple[int, int]], snake: bool = True) -> list[int]:
-    """
-    Convert ``(row, col)`` pairs to absolute LED indices.
-
-    Args:
-        coords: List of ``(row, col)`` pairs.
-        snake: Apply snake wiring. Default ``True``.
-
-    Returns:
-        List of integer LED indices.
-    """
-    return base.coords_to_led_indices(coords, NUM_COLS, snake=snake)
-
-
 def get_leds_for_time(
     hours: int,
     minutes: int,
@@ -146,32 +133,13 @@ def get_leds_for_time(
     Returns:
         :class:`~wordclock.layouts.base.LedResult` dict.
     """
-    sentence = time_to_sentence(hours, minutes)
-    coords = sentence_to_coords(sentence, grid)
-    led_indices = coords_to_led_indices(coords, snake=snake)
-    return LedResult(
-        sentence=sentence,
-        coords=coords,
-        led_indices=led_indices,
-        hours=hours,
-        minutes=minutes,
+    return base.build_leds_for_time(
+        hours,
+        minutes,
+        grid=grid if grid is not None else GRID_RAW,
+        num_rows=NUM_ROWS,
+        num_cols=NUM_COLS,
+        time_to_sentence_fn=time_to_sentence,
+        normalize=_NORMALIZE,
+        snake=snake,
     )
-
-
-if __name__ == "__main__":
-    cases = [
-        (1, 0),
-        (2, 5),
-        (10, 15),
-        (12, 30),
-        (4, 45),
-        (11, 55),
-    ]
-    print("=" * 55)
-    print("  Catalan word clock — layout test")
-    print("=" * 55)
-    print(f"\n{'TIME':<8} | {'SENTENCE'}")
-    print("-" * 40)
-    for h, m in cases:
-        res = get_leds_for_time(h, m)
-        print(f"{h:02d}:{m:02d}    | {res['sentence']}")

--- a/wordclock/layouts/english.py
+++ b/wordclock/layouts/english.py
@@ -23,9 +23,10 @@ from __future__ import annotations
 
 import wordclock.layouts.base as base
 from wordclock.layouts.base import LedResult
+from wordclock.layouts.registry import Language
 from wordclock.layouts.utils import load_grid
 
-GRID_RAW: list[str] = load_grid("english")
+GRID_RAW: list[str] = load_grid(Language.english)
 
 NUM_ROWS: int = len(GRID_RAW)
 NUM_COLS: int = len(GRID_RAW[0])
@@ -105,20 +106,6 @@ def sentence_to_coords(sentence: str, grid: list[str] | None = None) -> list[tup
     )
 
 
-def coords_to_led_indices(coords: list[tuple[int, int]], snake: bool = True) -> list[int]:
-    """
-    Convert ``(row, col)`` pairs to absolute LED indices.
-
-    Args:
-        coords: List of ``(row, col)`` pairs.
-        snake: Apply snake wiring. Default ``True``.
-
-    Returns:
-        List of integer LED indices.
-    """
-    return base.coords_to_led_indices(coords, NUM_COLS, snake=snake)
-
-
 def get_leds_for_time(
     hours: int,
     minutes: int,
@@ -137,39 +124,12 @@ def get_leds_for_time(
     Returns:
         :class:`~wordclock.layouts.base.LedResult` dict.
     """
-    sentence = time_to_sentence(hours, minutes)
-    coords = sentence_to_coords(sentence, grid)
-    led_indices = coords_to_led_indices(coords, snake=snake)
-    return LedResult(
-        sentence=sentence,
-        coords=coords,
-        led_indices=led_indices,
-        hours=hours,
-        minutes=minutes,
+    return base.build_leds_for_time(
+        hours,
+        minutes,
+        grid=grid if grid is not None else GRID_RAW,
+        num_rows=NUM_ROWS,
+        num_cols=NUM_COLS,
+        time_to_sentence_fn=time_to_sentence,
+        snake=snake,
     )
-
-
-if __name__ == "__main__":
-    cases = [
-        (12, 0),
-        (1, 0),
-        (3, 5),
-        (6, 10),
-        (10, 15),
-        (8, 20),
-        (4, 25),
-        (7, 30),
-        (11, 35),
-        (2, 40),
-        (9, 45),
-        (5, 50),
-        (3, 55),
-    ]
-    print("=" * 55)
-    print("  English word clock — layout test")
-    print("=" * 55)
-    print(f"\n{'TIME':<8} | {'SENTENCE'}")
-    print("-" * 40)
-    for h, m in cases:
-        res = get_leds_for_time(h, m)
-        print(f"{h:02d}:{m:02d}    | {res['sentence']}")

--- a/wordclock/layouts/registry.py
+++ b/wordclock/layouts/registry.py
@@ -1,20 +1,26 @@
-"""Layout registry — maps language names to their layout modules."""
-
 from __future__ import annotations
 
 import importlib
+from enum import StrEnum
 
 from wordclock.layouts.base import LayoutModule
 
-SUPPORTED_LANGUAGES: tuple[str, ...] = ("english", "catalan", "spanish")
+
+class Language(StrEnum):
+    english = "english"
+    catalan = "catalan"
+    spanish = "spanish"
 
 
-def get_layout(lang: str) -> LayoutModule:
+SUPPORTED_LANGUAGES: tuple[str, ...] = tuple(lang.value for lang in Language)
+
+
+def get_layout(lang: str | Language) -> LayoutModule:
     """
     Return the layout module for *lang*.
 
     Args:
-        lang: Language name, must be one of :data:`SUPPORTED_LANGUAGES`.
+        lang: Language name or :class:`Language` enum value.
 
     Returns:
         The layout module satisfying the :class:`~wordclock.layouts.base.LayoutModule` protocol.
@@ -22,6 +28,7 @@ def get_layout(lang: str) -> LayoutModule:
     Raises:
         ValueError: If *lang* is not a supported language.
     """
-    if lang not in SUPPORTED_LANGUAGES:
+    key = lang.value if isinstance(lang, Language) else lang
+    if key not in SUPPORTED_LANGUAGES:
         raise ValueError(f"Unknown language: {lang!r}")
-    return importlib.import_module(f"wordclock.layouts.{lang}")  # type: ignore[return-value]
+    return importlib.import_module(f"wordclock.layouts.{key}")  # type: ignore[return-value]

--- a/wordclock/layouts/spanish.py
+++ b/wordclock/layouts/spanish.py
@@ -16,9 +16,10 @@ from __future__ import annotations
 
 import wordclock.layouts.base as base
 from wordclock.layouts.base import LedResult
+from wordclock.layouts.registry import Language
 from wordclock.layouts.utils import load_grid
 
-GRID_RAW: list[str] = load_grid("spanish")
+GRID_RAW: list[str] = load_grid(Language.spanish)
 
 NUM_ROWS: int = len(GRID_RAW)
 NUM_COLS: int = len(GRID_RAW[0])
@@ -103,20 +104,6 @@ def sentence_to_coords(sentence: str, grid: list[str] | None = None) -> list[tup
     )
 
 
-def coords_to_led_indices(coords: list[tuple[int, int]], snake: bool = True) -> list[int]:
-    """
-    Convert ``(row, col)`` pairs to absolute LED indices.
-
-    Args:
-        coords: List of ``(row, col)`` pairs.
-        snake: Apply snake wiring. Default ``True``.
-
-    Returns:
-        List of integer LED indices.
-    """
-    return base.coords_to_led_indices(coords, NUM_COLS, snake=snake)
-
-
 def get_leds_for_time(
     hours: int,
     minutes: int,
@@ -135,31 +122,13 @@ def get_leds_for_time(
     Returns:
         :class:`~wordclock.layouts.base.LedResult` dict.
     """
-    sentence = time_to_sentence(hours, minutes)
-    coords = sentence_to_coords(sentence, grid)
-    led_indices = coords_to_led_indices(coords, snake=snake)
-    return LedResult(
-        sentence=sentence,
-        coords=coords,
-        led_indices=led_indices,
-        hours=hours,
-        minutes=minutes,
+    return base.build_leds_for_time(
+        hours,
+        minutes,
+        grid=grid if grid is not None else GRID_RAW,
+        num_rows=NUM_ROWS,
+        num_cols=NUM_COLS,
+        time_to_sentence_fn=time_to_sentence,
+        normalize=_NORMALIZE,
+        snake=snake,
     )
-
-
-if __name__ == "__main__":
-    cases = [
-        (1, 0),
-        (2, 15),
-        (10, 30),
-        (4, 45),
-        (12, 50),
-    ]
-    print("=" * 55)
-    print("  Spanish word clock — layout test")
-    print("=" * 55)
-    print(f"\n{'TIME':<8} | {'SENTENCE'}")
-    print("-" * 40)
-    for h, m in cases:
-        res = get_leds_for_time(h, m)
-        print(f"{h:02d}:{m:02d}    | {res['sentence']}")

--- a/wordclock/layouts/utils/__init__.py
+++ b/wordclock/layouts/utils/__init__.py
@@ -1,5 +1,3 @@
-"""Shared utilities for word-clock layout modules."""
-
 from __future__ import annotations
 
 from wordclock.layouts.utils.cli import main

--- a/wordclock/layouts/utils/cli.py
+++ b/wordclock/layouts/utils/cli.py
@@ -1,44 +1,46 @@
-"""CLI entry point for the wordclock-generate command."""
-
 from __future__ import annotations
 
-from argparse import ArgumentParser
+from typing import Annotated
+
+import typer
 
 from wordclock.layouts.utils.layout import Layout, generate_static
 
+app = typer.Typer()
 
-def main() -> None:
-    parser = ArgumentParser(description="Generate and persist a static word-clock layout.")
-    parser.add_argument(
-        "--lang",
-        choices=Layout.available(),
-        help="Language to generate. Prompted interactively if omitted.",
-    )
-    parser.add_argument("--seed", type=int, default=None, help="Random seed (optional).")
-    args = parser.parse_args()
 
+@app.command()
+def main(
+    lang: Annotated[str | None, typer.Option(help="Language to generate")] = None,
+    seed: Annotated[int | None, typer.Option(help="Random seed")] = None,
+) -> None:
     available = Layout.available()
 
-    if args.lang:
-        lang = args.lang
-    else:
-        print("Available languages:")
+    if lang is None:
+        typer.echo("Available languages:")
         for i, name in enumerate(available, start=1):
-            print(f"  {i}. {name}")
-        choice = input("Select language (name or number): ").strip()
+            typer.echo(f"  {i}. {name}")
+        typer.echo("  0. Exit")
+        choice = typer.prompt("Select language (name or number)").strip()
+        if choice in ("0", "q", "exit", "quit", ""):
+            typer.echo("Aborted.")
+            raise typer.Exit(0)
         if choice.isdigit():
             idx = int(choice) - 1
             if not (0 <= idx < len(available)):
-                print(f"Invalid selection: {choice}")
-                raise SystemExit(1)
+                typer.echo(f"Invalid selection: {choice}", err=True)
+                raise typer.Exit(1)
             lang = available[idx]
         elif choice in available:
             lang = choice
         else:
-            print(f"Unknown language: {choice!r}")
-            raise SystemExit(1)
+            typer.echo(f"Unknown language: {choice!r}", err=True)
+            raise typer.Exit(1)
+    elif lang not in available:
+        typer.echo(f"Unknown language: {lang!r}", err=True)
+        raise typer.Exit(1)
 
-    static = generate_static(lang, seed=args.seed)
-    print(f"Generated static layout for '{lang}':")
+    static = generate_static(lang, seed=seed)
+    typer.echo(f"Generated static layout for '{lang}':")
     for row in static:
-        print(f"  {row}")
+        typer.echo(f"  {row}")

--- a/wordclock/layouts/utils/grid.py
+++ b/wordclock/layouts/utils/grid.py
@@ -1,5 +1,3 @@
-"""Pure grid-manipulation utilities."""
-
 from __future__ import annotations
 
 from random import Random

--- a/wordclock/layouts/utils/layout.py
+++ b/wordclock/layouts/utils/layout.py
@@ -1,5 +1,3 @@
-"""Layout class and module-level convenience wrappers."""
-
 from __future__ import annotations
 
 import json
@@ -21,8 +19,9 @@ class Layout:
         Args:
             name: Layout name matching a file in ``data/`` (e.g. ``"english"``).
         """
-        self.name = name
-        self._path: Path = _DATA_DIR / f"{name}.json"
+        key = name.value if hasattr(name, "value") else name
+        self.name = key
+        self._path: Path = _DATA_DIR / f"{key}.json"
         self._data: dict = json.loads(self._path.read_text(encoding="utf-8"))
 
     @classmethod

--- a/wordclock/led/controller.py
+++ b/wordclock/led/controller.py
@@ -16,16 +16,17 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from logging import getLogger
 
+from wordclock.config import (
+    LED_BRIGHTNESS,
+    LED_COLOR,
+    LED_COUNT,
+    LED_DMA,
+    LED_FREQ_HZ,
+    LED_PIN,
+)
+
 logger = getLogger(__name__)
 
-DEFAULT_LED_COUNT = 256
-DEFAULT_LED_PIN = 18
-DEFAULT_BRIGHTNESS = 128
-DEFAULT_FREQ_HZ = 800_000
-DEFAULT_DMA = 10
-
-
-_DEFAULT_COLOR = (255, 200, 50)
 _ANSI_BOLD = "\033[1m"
 _ANSI_DIM = "\033[2m"
 _ANSI_RESET = "\033[0m"
@@ -34,8 +35,8 @@ _ANSI_RESET = "\033[0m"
 class BaseLedController(ABC):
     def __init__(
         self,
-        num_leds: int = DEFAULT_LED_COUNT,
-        brightness: int = DEFAULT_BRIGHTNESS,
+        num_leds: int = LED_COUNT,
+        brightness: int = LED_BRIGHTNESS,
         grid: list[str] | None = None,
     ):
         self.num_leds = num_leds
@@ -63,7 +64,7 @@ class BaseLedController(ABC):
     def display_leds(
         self,
         active_indices: list[int],
-        color: tuple[int, int, int] = (255, 200, 50),
+        color: tuple[int, int, int] = LED_COLOR,
     ) -> None:
         self.clear()
         self.set_pixels(active_indices, *color)
@@ -76,11 +77,11 @@ class BaseLedController(ABC):
 class RealLedController(BaseLedController):
     def __init__(
         self,
-        num_leds=DEFAULT_LED_COUNT,
-        brightness=DEFAULT_BRIGHTNESS,
-        pin=DEFAULT_LED_PIN,
-        freq_hz=DEFAULT_FREQ_HZ,
-        dma=DEFAULT_DMA,
+        num_leds: int = LED_COUNT,
+        brightness: int = LED_BRIGHTNESS,
+        pin: int = LED_PIN,
+        freq_hz: int = LED_FREQ_HZ,
+        dma: int = LED_DMA,
     ):
         super().__init__(num_leds, brightness)
         self._pin, self._freq_hz, self._dma = pin, freq_hz, dma
@@ -135,7 +136,7 @@ class MockLedController(BaseLedController):
     def display_leds(
         self,
         indices: list[int],
-        color: tuple[int, int, int] = _DEFAULT_COLOR,
+        color: tuple[int, int, int] = LED_COLOR,
     ) -> None:
         logger.info("LEDs on: %s  color=%s", indices, color)
         if self._grid is not None:
@@ -163,14 +164,19 @@ class MockLedController(BaseLedController):
 
 
 def create_controller(mock: bool = False, **kwargs) -> BaseLedController:
-    safe = {k: v for k, v in kwargs.items() if k in ("num_leds", "brightness", "grid")}
+    mock_kwargs = {k: v for k, v in kwargs.items() if k in ("num_leds", "brightness", "grid")}
+    real_kwargs = {
+        k: v for k, v in kwargs.items() if k in ("num_leds", "brightness", "pin", "freq_hz", "dma")
+    }
     if mock:
-        ctrl: BaseLedController = MockLedController(**safe)
+        ctrl: BaseLedController = MockLedController(**mock_kwargs)
+        ctrl.begin()
     else:
         try:
-            ctrl = RealLedController(**kwargs)
+            ctrl = RealLedController(**real_kwargs)
+            ctrl.begin()
         except RuntimeError:
             logger.warning("LED hardware unavailable — falling back to mock mode.")
-            ctrl = MockLedController(**safe)
-    ctrl.begin()
+            ctrl = MockLedController(**mock_kwargs)
+            ctrl.begin()
     return ctrl

--- a/wordclock/main.py
+++ b/wordclock/main.py
@@ -1,60 +1,38 @@
-"""CLI entry points for the wordclock package."""
-
 from __future__ import annotations
 
-from argparse import ArgumentParser
-from logging import DEBUG, INFO, basicConfig, getLogger
+from logging import DEBUG, INFO, basicConfig
+from typing import Annotated
 
-logger = getLogger(__name__)
+import typer
 
+from wordclock.config import API_HOST, API_PORT, CLOCK_INTERVAL, LED_BRIGHTNESS
+from wordclock.layouts.registry import Language
 
-def main() -> None:
-    parser = ArgumentParser(description="Wordclock — LED word clock")
-    parser.add_argument("--lang", default="english", choices=["english"])
-    parser.add_argument("--mock", action="store_true", help="Simulated LEDs")
-    parser.add_argument("--brightness", type=int, default=128)
-    parser.add_argument("--interval", type=int, default=30)
-    parser.add_argument("--debug", action="store_true")
-    args = parser.parse_args()
-
-    basicConfig(
-        level=DEBUG if args.debug else INFO,
-        format="%(asctime)s %(levelname)-8s %(name)s — %(message)s",
-    )
-
-    from wordclock.clock import run_clock
-
-    run_clock(lang=args.lang, mock=args.mock, brightness=args.brightness, interval=args.interval)
+_LOG_FORMAT = "%(asctime)s %(levelname)-8s %(message)s"
 
 
-def main_serve() -> None:
-    parser = ArgumentParser(description="Wordclock — clock loop + API server")
-    parser.add_argument("--lang", default="english", choices=["english"])
-    parser.add_argument("--mock", action="store_true", help="Simulated LEDs")
-    parser.add_argument("--brightness", type=int, default=128)
-    parser.add_argument("--interval", type=int, default=30)
-    parser.add_argument("--host", default="0.0.0.0")
-    parser.add_argument("--port", "-p", type=int, default=5000)
-    parser.add_argument("--debug", action="store_true")
-    args = parser.parse_args()
-
-    basicConfig(
-        level=DEBUG if args.debug else INFO,
-        format="%(asctime)s %(levelname)-8s %(name)s — %(message)s",
-    )
-
-    from wordclock.clock import serve
-
-    serve(
-        lang=args.lang,
-        mock=args.mock,
-        brightness=args.brightness,
-        interval=args.interval,
-        host=args.host,
-        port=args.port,
-        debug=args.debug,
-    )
+app = typer.Typer()
 
 
-if __name__ == "__main__":
-    main()
+@app.command(no_args_is_help=True)
+def main(
+    lang: Language = Language.catalan,
+    mock: Annotated[bool, typer.Option(help="Use mock LED controller")] = False,
+    display: Annotated[bool, typer.Option(help="Print grid to console (mock only)")] = False,
+    brightness: int = LED_BRIGHTNESS,
+    interval: int = CLOCK_INTERVAL,
+    host: str = API_HOST,
+    port: Annotated[int, typer.Option("--port", "-p")] = API_PORT,
+    debug: bool = False,
+) -> None:
+    basicConfig(level=DEBUG if debug else INFO, format=_LOG_FORMAT)
+
+    from wordclock.clock import WordClock
+
+    WordClock(
+        lang=lang.value,
+        mock=mock,
+        display=display,
+        brightness=brightness,
+        interval=interval,
+    ).serve(host=host, port=port, debug=debug)


### PR DESCRIPTION
## WordClock - Overview

 This PR is a broad refactor and cleanup of the Python package, consolidating the CLI, API, and layout logic into a cleaner, more consistent architecture.
                                                                                                                                                                              
  CLI & entry points                                                                                                                                                          
  - Replaced the three separate commands (wordclock, wordclock-api, wordclock-serve) with a single wordclock command built with Typer; kept wordclock-generate for grid       
  generation                                                                                                                                                                  
  - Added --display flag to print the LED grid to the console independently of --mock
  - Fixed crash when running without arguments (now shows help)                                                                                                               
  - Fixed crash on non-Pi hardware when rpi-ws281x is not installed (falls back to mock controller)                                                                           
                                                                                                                                                                              
  Architecture                                                                                                                                                                
  - Introduced WordClock class in clock.py to encapsulate clock loop and API lifecycle                                                                                        
  - Replaced threading with FastAPI lifespan + asyncio.create_task — the clock loop now runs inside uvicorn's event loop with no threads                                      
  - Extracted wordclock/config.py for all default constants                                                                             
  - Extracted wordclock/api/schemas.py for Pydantic response models                                                                                                           
  - Moved Language enum from main.py to registry.py; upgraded to StrEnum                                                                                                      
  - Added APIRouter(prefix="/api") to remove the repeated prefix from every route                                                                                             
  - Cached layout dims (NUM_ROWS, NUM_COLS) in app.state at startup so request handlers do no redundant work                                                                  
                                                                                                                                                                              
  Layouts                                                                                                                                                                     
  - Layout files now use the Language enum when calling load_grid() instead of bare strings                                                                                   
  - Added build_leds_for_time() to base.py; removed the copy-pasted coords_to_led_indices and get_leds_for_time boilerplate from each layout module                           
  - __main__ blocks removed from all three layout files                                                                                            
                                                                                                                                                                              
  Tests                                                                                                                                                                       
  - Added layout_test_mixin.py with AllTimesMixin, SentenceToCoordsMixin, and GetLedsForTimeMixin; updated all three layout test files to inherit from them, eliminating ~60  
  lines of duplicated test code                                                                                                                                               
                                                            
  Docs & tooling                                                                                                                                                              
  - Added Typer badge to README; fixed version badge (was stuck at 0.1.0)                                                                                                     
  - Added Motivation section to README                                                                                                                                        
  - bumpversion now updates both pyproject.toml and the README badge together                                                                                                 
  - /api/health version is now read from package metadata dynamically                                                                                                         
  - All ruff warnings resolved (unused imports, line length, import ordering)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] `uv run ruff check .` passes with no errors
- [x] `uv run pytest` passes with no failures
- [x] I have added tests that prove my fix is effective or that my feature works
